### PR TITLE
Add pageable ApiResponse for item listing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.1.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,10 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
             <scope>runtime</scope>

--- a/src/main/java/com/example/catalogo/controller/ItemController.java
+++ b/src/main/java/com/example/catalogo/controller/ItemController.java
@@ -4,8 +4,6 @@ import com.example.catalogo.dto.ApiResponse;
 import com.example.catalogo.entity.Item;
 import com.example.catalogo.service.IItemService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,12 +19,12 @@ public class ItemController {
 
     @GetMapping
     public ResponseEntity<ApiResponse<List<Item>>> all() {
-        Page<Item> page = service.findAll(Pageable.unpaged());
+        List<Item> items = service.findAll();
 
         ApiResponse<List<Item>> response = ApiResponse.<List<Item>>builder()
                 .success(true)
                 .status(HttpStatus.OK.value())
-                .data(page.getContent())
+                .data(items)
                 .build();
 
         return ResponseEntity.ok(response);

--- a/src/main/java/com/example/catalogo/controller/ItemController.java
+++ b/src/main/java/com/example/catalogo/controller/ItemController.java
@@ -21,11 +21,10 @@ public class ItemController {
     public ResponseEntity<ApiResponse<List<Item>>> all() {
         List<Item> items = service.findAll();
 
-        ApiResponse<List<Item>> response = ApiResponse.<List<Item>>builder()
-                .success(true)
-                .status(HttpStatus.OK.value())
-                .data(items)
-                .build();
+        ApiResponse<List<Item>> response = new ApiResponse<>();
+        response.setSuccess(true);
+        response.setStatus(HttpStatus.OK.value());
+        response.setData(items);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/example/catalogo/controller/ItemController.java
+++ b/src/main/java/com/example/catalogo/controller/ItemController.java
@@ -83,4 +83,23 @@ public class ItemController {
         response.setData(updated);
         return ResponseEntity.ok(response);
     }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> delete(@PathVariable Long id) {
+        ApiResponse<Void> response = new ApiResponse<>();
+
+        Item existing = service.findById(id);
+        if (existing == null) {
+            response.setSuccess(false);
+            response.setStatus(HttpStatus.NOT_FOUND.value());
+            response.setErrors(java.util.List.of(new ApiError("id", "Item no encontrado")));
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+        }
+
+        service.delete(id);
+
+        response.setSuccess(true);
+        response.setStatus(HttpStatus.NO_CONTENT.value());
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).body(response);
+    }
 }

--- a/src/main/java/com/example/catalogo/controller/ItemController.java
+++ b/src/main/java/com/example/catalogo/controller/ItemController.java
@@ -53,4 +53,34 @@ public class ItemController {
 
         return ResponseEntity.ok(response);
     }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<Item>> update(@PathVariable Long id,
+                                                    @Valid @RequestBody Item item,
+                                                    BindingResult bindingResult) {
+        ApiResponse<Item> response = new ApiResponse<>();
+
+        if (bindingResult.hasErrors()) {
+            response.setSuccess(false);
+            response.setStatus(HttpStatus.BAD_REQUEST.value());
+            List<ApiError> errors = bindingResult.getFieldErrors().stream()
+                    .map(err -> new ApiError(err.getField(), err.getDefaultMessage()))
+                    .toList();
+            response.setErrors(errors);
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+        }
+
+        Item updated = service.update(id, item);
+        if (updated == null) {
+            response.setSuccess(false);
+            response.setStatus(HttpStatus.NOT_FOUND.value());
+            response.setErrors(java.util.List.of(new ApiError("id", "Item no encontrado")));
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+        }
+
+        response.setSuccess(true);
+        response.setStatus(HttpStatus.OK.value());
+        response.setData(updated);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/example/catalogo/controller/ItemController.java
+++ b/src/main/java/com/example/catalogo/controller/ItemController.java
@@ -2,6 +2,7 @@ package com.example.catalogo.controller;
 
 import com.example.catalogo.dto.ApiResponse;
 import com.example.catalogo.entity.Item;
+import com.example.catalogo.dto.ItemDto;
 import com.example.catalogo.service.IItemService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -33,7 +34,7 @@ public class ItemController {
     }
 
     @PostMapping
-    public ResponseEntity<ApiResponse<Item>> create(@Valid @RequestBody Item item, BindingResult bindingResult) {
+    public ResponseEntity<ApiResponse<Item>> create(@Valid @RequestBody ItemDto itemDto, BindingResult bindingResult) {
         ApiResponse<Item> response = new ApiResponse<>();
 
         if (bindingResult.hasErrors()) {
@@ -46,6 +47,8 @@ public class ItemController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
         }
 
+        Item item = new Item();
+        item.setNombre(itemDto.getNombre());
         Item created = service.create(item);
         response.setSuccess(true);
         response.setStatus(HttpStatus.OK.value());
@@ -56,7 +59,7 @@ public class ItemController {
 
     @PutMapping("/{id}")
     public ResponseEntity<ApiResponse<Item>> update(@PathVariable Long id,
-                                                    @Valid @RequestBody Item item,
+                                                    @Valid @RequestBody ItemDto itemDto,
                                                     BindingResult bindingResult) {
         ApiResponse<Item> response = new ApiResponse<>();
 
@@ -70,6 +73,8 @@ public class ItemController {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
         }
 
+        Item item = new Item();
+        item.setNombre(itemDto.getNombre());
         Item updated = service.update(id, item);
         if (updated == null) {
             response.setSuccess(false);

--- a/src/main/java/com/example/catalogo/controller/ItemController.java
+++ b/src/main/java/com/example/catalogo/controller/ItemController.java
@@ -24,12 +24,12 @@ public class ItemController {
     public ResponseEntity<ApiResponse<List<Item>>> all(Pageable pageable) {
         Page<Item> page = service.findAll(pageable);
 
-        Pagination pagination = Pagination.builder()
-                .page(page.getNumber())
-                .pageSize(page.getSize())
-                .totalElements(page.getTotalElements())
-                .totalPages(page.getTotalPages())
-                .build();
+        Pagination pagination = new Pagination(
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages()
+        );
 
         ApiResponse<List<Item>> response = ApiResponse.<List<Item>>builder()
                 .success(true)

--- a/src/main/java/com/example/catalogo/controller/ItemController.java
+++ b/src/main/java/com/example/catalogo/controller/ItemController.java
@@ -1,7 +1,6 @@
 package com.example.catalogo.controller;
 
 import com.example.catalogo.dto.ApiResponse;
-import com.example.catalogo.dto.Pagination;
 import com.example.catalogo.entity.Item;
 import com.example.catalogo.service.IItemService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,7 +11,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 
 @RestController
 @RequestMapping("/items")
@@ -22,22 +20,14 @@ public class ItemController {
     private IItemService service;
 
     @GetMapping
-    public ResponseEntity<ApiResponse<List<Item>>> all(
+    public ResponseEntity<ApiResponse<Page<Item>>> all(
             @PageableDefault(size = 20, page = 0) Pageable pageable) {
         Page<Item> page = service.findAll(pageable);
 
-        Pagination pagination = Pagination.builder()
-                .page(page.getNumber())
-                .pageSize(page.getSize())
-                .totalElements(page.getTotalElements())
-                .totalPages(page.getTotalPages())
-                .build();
-
-        ApiResponse<List<Item>> response = ApiResponse.<List<Item>>builder()
+        ApiResponse<Page<Item>> response = ApiResponse.<Page<Item>>builder()
                 .success(true)
                 .status(HttpStatus.OK.value())
-                .data(page.getContent())
-                .pagination(pagination)
+                .data(page)
                 .build();
 
         return ResponseEntity.ok(response);

--- a/src/main/java/com/example/catalogo/controller/ItemController.java
+++ b/src/main/java/com/example/catalogo/controller/ItemController.java
@@ -7,6 +7,7 @@ import com.example.catalogo.service.IItemService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,15 +22,16 @@ public class ItemController {
     private IItemService service;
 
     @GetMapping
-    public ResponseEntity<ApiResponse<List<Item>>> all(Pageable pageable) {
+    public ResponseEntity<ApiResponse<List<Item>>> all(
+            @PageableDefault(size = 20, page = 0) Pageable pageable) {
         Page<Item> page = service.findAll(pageable);
 
-        Pagination pagination = new Pagination(
-                page.getNumber(),
-                page.getSize(),
-                page.getTotalElements(),
-                page.getTotalPages()
-        );
+        Pagination pagination = Pagination.builder()
+                .page(page.getNumber())
+                .pageSize(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .build();
 
         ApiResponse<List<Item>> response = ApiResponse.<List<Item>>builder()
                 .success(true)

--- a/src/main/java/com/example/catalogo/controller/ItemController.java
+++ b/src/main/java/com/example/catalogo/controller/ItemController.java
@@ -6,10 +6,10 @@ import com.example.catalogo.service.IItemService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import java.util.List;
 
 
 @RestController
@@ -20,14 +20,13 @@ public class ItemController {
     private IItemService service;
 
     @GetMapping
-    public ResponseEntity<ApiResponse<Page<Item>>> all(
-            @PageableDefault(size = 20, page = 0) Pageable pageable) {
-        Page<Item> page = service.findAll(pageable);
+    public ResponseEntity<ApiResponse<List<Item>>> all() {
+        Page<Item> page = service.findAll(Pageable.unpaged());
 
-        ApiResponse<Page<Item>> response = ApiResponse.<Page<Item>>builder()
+        ApiResponse<List<Item>> response = ApiResponse.<List<Item>>builder()
                 .success(true)
                 .status(HttpStatus.OK.value())
-                .data(page)
+                .data(page.getContent())
                 .build();
 
         return ResponseEntity.ok(response);

--- a/src/main/java/com/example/catalogo/controller/ItemController.java
+++ b/src/main/java/com/example/catalogo/controller/ItemController.java
@@ -1,8 +1,14 @@
 package com.example.catalogo.controller;
 
+import com.example.catalogo.dto.ApiResponse;
+import com.example.catalogo.dto.Pagination;
 import com.example.catalogo.entity.Item;
 import com.example.catalogo.service.IItemService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -15,8 +21,24 @@ public class ItemController {
     private IItemService service;
 
     @GetMapping
-    public List<Item> all() {
-        return service.findAll();
+    public ResponseEntity<ApiResponse<List<Item>>> all(Pageable pageable) {
+        Page<Item> page = service.findAll(pageable);
+
+        Pagination pagination = Pagination.builder()
+                .page(page.getNumber())
+                .pageSize(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .build();
+
+        ApiResponse<List<Item>> response = ApiResponse.<List<Item>>builder()
+                .success(true)
+                .status(HttpStatus.OK.value())
+                .data(page.getContent())
+                .pagination(pagination)
+                .build();
+
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping

--- a/src/main/java/com/example/catalogo/controller/ItemController.java
+++ b/src/main/java/com/example/catalogo/controller/ItemController.java
@@ -7,6 +7,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import jakarta.validation.Valid;
+import org.springframework.validation.BindingResult;
+import com.example.catalogo.dto.ApiError;
 import java.util.List;
 
 
@@ -30,7 +33,24 @@ public class ItemController {
     }
 
     @PostMapping
-    public Item create(@RequestBody Item item) {
-        return service.create(item);
+    public ResponseEntity<ApiResponse<Item>> create(@Valid @RequestBody Item item, BindingResult bindingResult) {
+        ApiResponse<Item> response = new ApiResponse<>();
+
+        if (bindingResult.hasErrors()) {
+            response.setSuccess(false);
+            response.setStatus(HttpStatus.BAD_REQUEST.value());
+            java.util.List<ApiError> errors = bindingResult.getFieldErrors().stream()
+                    .map(err -> new ApiError(err.getField(), err.getDefaultMessage()))
+                    .toList();
+            response.setErrors(errors);
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+        }
+
+        Item created = service.create(item);
+        response.setSuccess(true);
+        response.setStatus(HttpStatus.OK.value());
+        response.setData(created);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/example/catalogo/dto/ItemDto.java
+++ b/src/main/java/com/example/catalogo/dto/ItemDto.java
@@ -1,0 +1,16 @@
+package com.example.catalogo.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ItemDto {
+    @NotNull(message = "el nombre es obligatorio")
+    private String nombre;
+}

--- a/src/main/java/com/example/catalogo/entity/Item.java
+++ b/src/main/java/com/example/catalogo/entity/Item.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
 
 @Entity
 public class Item {
@@ -12,6 +13,7 @@ public class Item {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @NotNull(message = "el nombre es obligatorio")
     private String nombre;
 
     public Item() {

--- a/src/main/java/com/example/catalogo/service/IItemService.java
+++ b/src/main/java/com/example/catalogo/service/IItemService.java
@@ -2,8 +2,7 @@ package com.example.catalogo.service;
 
 import com.example.catalogo.entity.Item;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import java.util.List;
 
 
 /**
@@ -11,7 +10,7 @@ import org.springframework.data.domain.Pageable;
  */
 public interface IItemService {
 
-    Page<Item> findAll(Pageable pageable);
+    List<Item> findAll();
 
     Item findById(Long id);
 

--- a/src/main/java/com/example/catalogo/service/IItemService.java
+++ b/src/main/java/com/example/catalogo/service/IItemService.java
@@ -2,14 +2,16 @@ package com.example.catalogo.service;
 
 import com.example.catalogo.entity.Item;
 
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 
 /**
  * Servicio que define operaciones CRUD para {@link Item}.
  */
 public interface IItemService {
 
-    List<Item> findAll();
+    Page<Item> findAll(Pageable pageable);
 
     Item findById(Long id);
 

--- a/src/main/java/com/example/catalogo/service/jpa/ItemServiceImpl.java
+++ b/src/main/java/com/example/catalogo/service/jpa/ItemServiceImpl.java
@@ -6,7 +6,8 @@ import com.example.catalogo.service.IItemService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 @Service
 public class ItemServiceImpl implements IItemService {
@@ -15,8 +16,8 @@ public class ItemServiceImpl implements IItemService {
     private ItemRepository repository;
 
     @Override
-    public List<Item> findAll() {
-        return repository.findAll();
+    public Page<Item> findAll(Pageable pageable) {
+        return repository.findAll(pageable);
     }
 
     @Override

--- a/src/main/java/com/example/catalogo/service/jpa/ItemServiceImpl.java
+++ b/src/main/java/com/example/catalogo/service/jpa/ItemServiceImpl.java
@@ -5,9 +5,8 @@ import com.example.catalogo.repository.ItemRepository;
 import com.example.catalogo.service.IItemService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import java.util.List;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 @Service
 public class ItemServiceImpl implements IItemService {
@@ -16,8 +15,8 @@ public class ItemServiceImpl implements IItemService {
     private ItemRepository repository;
 
     @Override
-    public Page<Item> findAll(Pageable pageable) {
-        return repository.findAll(pageable);
+    public List<Item> findAll() {
+        return repository.findAll();
     }
 
     @Override


### PR DESCRIPTION
## Summary
- return paginated items wrapped in an ApiResponse from `/items`
- update `IItemService` and implementation to support `Pageable`

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861c9952218832fa6ab13857ea84e92